### PR TITLE
Potential fix for code scanning alert no. 19: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,8 @@
 name: Build images
+permissions:
+  contents: read
+  packages: write
+  actions: write
 
 on:
   push:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,6 @@
 name: Build images
 permissions:
   contents: read
-  packages: write
   actions: write
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/CBIIT/sec_poc/security/code-scanning/19](https://github.com/CBIIT/sec_poc/security/code-scanning/19)

To fix the issue, add a `permissions` block at the root of the workflow file. This block will define the least privileges required for the workflow to function correctly. Based on the actions used in the workflow, the following permissions are appropriate:
- `contents: read` for accessing repository files.
- `actions: write` for saving to actions cache.

The `permissions` block should be added after the `name` field and before the `on` field in the workflow file.
